### PR TITLE
fix usage for koa-graphql, fix #88

### DIFF
--- a/src/Instrument.js
+++ b/src/Instrument.js
@@ -65,9 +65,9 @@ export const opticsMiddleware = (req, res, next) => {
 };
 
 export const koaMiddleware = (ctx, next) => {
-  preRequest(ctx.req);
+  preRequest(ctx.request);
 
-  return next().then(() => postRequest(ctx.req));
+  return next().then(() => postRequest(ctx.request));
 };
 
 export const instrumentHapiServer = (server) => {


### PR DESCRIPTION
@rohit2b 

this fixes for koa-graphql

but it breaks on https://github.com/apollographql/optics-agent-js/blob/master/src/Report.js#L216

`req.connection` is undefined
