### PR TITLE
Ensure koa2 compatibility in report

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,24 @@ OpticsAgent.instrumentHapiServer(hapiServer);
 
 #### Koa
 
-Koa is not currently supported. Contributions are welcome.
+Koa is not officially supported but, thank community, it works:
+
+```js
+app.use(OpticsAgent.koaMiddleware());
+router.post(
+  '/graphql',
+  graphqlKoa(async ctx => {
+    // create an optic context
+    const opticsContext = OpticsAgent.context(ctx.request);
+    // create a context for each request
+    const context = { opticsContext };
+    return {
+      schema: OpticsAgent.instrumentSchema(schema),
+      context,
+    };
+  })
+);
+```
 
 ### Add a context to each graphql request
 

--- a/src/Report.js
+++ b/src/Report.js
@@ -230,7 +230,11 @@ export const sendTrace = (agent, context, info, resolvers) => {
     trace.client_name = client_name;  // eslint-disable-line camelcase
     trace.client_version = client_version;  // eslint-disable-line camelcase
 
-    trace.client_addr = req.connection.remoteAddress; // XXX x-forwarded-for?
+    // koa2 and express both have req.ip that use x-forwarded for or fallback to remoteAdress
+    // req.connection.remoteAdress remains for compatibility with hapi but that don't use x-forwarded-for header
+    // XXX : use request.info.remoteAddress in Hapi
+    // XXX : maybe use https://www.npmjs.com/package/request-ip to support other way to retrieve request's IP address. 
+    trace.client_addr = req.ip || req.connection.remoteAddress;
     trace.http = new Trace.HTTPInfo();
     trace.http.host = req.headers.host;
     trace.http.path = req.url;


### PR DESCRIPTION
As discussed in slack.

After #89 by @sibelius, one line was still undefined.

Using req.ip:
- ensure koa2 compatibility
- trust x-forwarded-for header on koa or express 4

# Test plan

I did the same modification that what I hardcoded on node_modules/optics-agent-js/dist/Report.js.
Before, koa2 was crashing, after it don't.