### PR TITLE
Ignore password fields from getting sent to optics

### DIFF
--- a/src/Report.js
+++ b/src/Report.js
@@ -229,6 +229,7 @@ export const sendTrace = (agent, context, info, resolvers) => {
     if (agent.reportVariables) {
       trace.details.variables = {};
       Object.keys(info.variableValues).forEach((k) => {
+        if(k.match(/password/) return; 
         trace.details.variables[k] = new Buffer(JSON.stringify(info.variableValues[k]), 'utf8');
       });
     }


### PR DESCRIPTION
Not sure if this is the right place, but other services, like Sentry, will filter fields that are sensitive. I think not sending along any fields matching the name password makes sense. Let me know if this is the wrong place or if there's a better way you want this done. Hopefully you all agree this is necessary!