### PR TITLE
Don’t fire the request callback on errors until we are out of retries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Change log
 
+### 1.1.7
+* Fixed an issue where request retries would print superfluous errors to the console.
+
 ### 1.1.4
 * Community support for koa2, thanks to tychota and sibelius
 * Ugprade to graphql-tools 1.x

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "optics-agent",
-  "version": "1.1.6",
+  "version": "1.1.7",
   "description": "Apollo Optics Agent for GraphQL-js",
   "main": "dist/index.js",
   "scripts": {

--- a/src/Report.js
+++ b/src/Report.js
@@ -95,9 +95,12 @@ const retryRequest = (options, callback) => {
           delayMs *= 2;
           request(options, wrapper);
         }, delayMs);
+      } else {
+        callback(err, res, body);
       }
+    } else {
+      callback(err, res, body);
     }
-    callback(err, res, body);
   };
   return request(options, wrapper);
 };


### PR DESCRIPTION
Should help with experiences like #97 